### PR TITLE
Enhance user authentication

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           BOT_TOKEN: SOME_STRING
           APP_URL: http://example.com
+          COOKIE_ENCRYPTION_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
         run: npm run build
 
       - name: Docker meta

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - **Engine pinning:** `.npmrc` sets `engine-strict=true` and CI locks Node.js 24 + pnpm 10
 - **Bash + `[secret]` in paths:** route paths contain `[` `]` — always quote paths in shell (fish/zsh treat unquoted brackets as globs)
 - **Build requires `BOT_TOKEN`:** set any dummy value like `SOME_STRING` for local building; the bot is a grammy instance and the token becomes the HMAC key for Telegram Login Widget auth
-- **Env vars** (from `.env`, README, or `.mise.toml` in dev): `BOT_TOKEN`, `APP_URL`, `SECRET`, `DB_URL` (SQLite, e.g. `file:data/db.sqlite3`). `.env` and `.mise.toml` are gitignored.
+- **Env vars** (from `.env`, README, or `.mise.toml` in dev): `BOT_TOKEN`, `APP_URL`, `SECRET`, `COOKIE_ENCRYPTION_KEY`, `DB_URL` (SQLite, e.g. `file:data/db.sqlite3`). `.env` and `.mise.toml` are gitignored.
 - **App timezone:** `Europe/Minsk` (see `src/lib/server/utils.ts`)
 - **Docker:** `node:24-alpine`, port `3000` (the README docker-compose maps 8000→3000)
 - **Tests:** server-side only (no component/svelte tests). Vitest config uses `projects` with a `server` project filtered by `include: ['src/**/*.{test,spec}.{js,ts}']` and `exclude: ['src/**/*.svelte.{test,spec}.{js,ts}']`. Setup in `src/vitest-setup.ts` mocks env vars and sets `DB_URL=:memory:`. Drizzle migrations run in `database.test.ts` via `drizzle-orm/libsql/migrator` (once per suite via global flag).
@@ -42,7 +42,7 @@
 - `src/lib/server/db/store.ts` — Drizzle client instance (`drizzle(env.DB_URL!)`)
 - `src/lib/server/db/migrate.ts` — `runMigrations()` called from `hooks.server.ts`
 - `src/lib/server/database.ts` — DB access layer (CRUD locations, menus, orders)
-- `src/lib/server/auth.ts` — `checkAdminAuth`, `checkClientAuth` (Telegram Login Widget)
+- `src/lib/server/auth.ts` — `checkAdminAuth`, `authenticateUser` (Telegram Login Widget + session cookies)
 - `src/lib/server/bot.ts` — `init`, `stop`, `sendOrder`, `sendOrderButton`
 - `src/lib/server/parser.ts` — Parse forwarded Telegram order messages → TSV
 - `src/lib/ordersTsv.ts` — TSV generation with precedence-based column ordering

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ services:
       APP_URL: 'url приложения'
       SECRET: 'секрет для доступа к админке'
       DB_URL: 'file:/app/data/db.sqlite3'
+      COOKIE_ENCRYPTION_KEY: 'generate using <openssl rand -base64 32>'
     volumes:
       - './data:/app/data'
 ```

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,9 +3,7 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		interface Locals {
-			userId?: string;
-		}
+		// interface Locals {}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/demo.spec.ts
+++ b/src/demo.spec.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('sum test', () => {
-	it('adds 1 + 2 to equal 3', () => {
-		expect(1 + 2).toBe(3);
-	});
-});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,9 @@
+import { validateConfig } from '$lib/server/config';
 import { runMigrations } from '$lib/server/db/migrate';
 import * as bot from '$lib/server/bot';
 import { scheduleOldLinkDeletion } from '$lib/server/menu-link';
 
+validateConfig();
 await runMigrations();
 bot.init();
 scheduleOldLinkDeletion();

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,9 +1,14 @@
-import { error } from '@sveltejs/kit';
+import { type Cookies, error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { logger } from '$lib/server/logger';
+import { Duration } from '@js-joda/core';
+import { decrypt, encrypt } from '$lib/server/encryption';
 
-const { BOT_TOKEN, SECRET } = env;
-const TG_AUTH_TTL_SECONDS = 24 * 60 * 60;
+const { BOT_TOKEN, SECRET, COOKIE_ENCRYPTION_KEY } = env;
+
+const tgUrlAuthTtlMilli = Duration.ofSeconds(60).toMillis();
+const cookieTtlMilli = Duration.ofHours(18).toMillis();
+const cookieName = 'session';
 
 export function checkAdminAuth(params: { secret: string }) {
 	if (params.secret !== SECRET) throw error(404, 'Not Found');
@@ -32,8 +37,26 @@ const isLinkSignatureValid = async (hash: string, data: string) => {
 	return hash === hex(digest);
 };
 
-export const checkClientAuth = async (searchParams: URLSearchParams) => {
-	if (!searchParams) return null;
+function serializeSession(session: Session): string {
+	const json = JSON.stringify(session);
+	return encrypt(json, COOKIE_ENCRYPTION_KEY!);
+}
+
+function deserializeSession(ciphertext: string): Session | null {
+	try {
+		const json = decrypt(ciphertext, COOKIE_ENCRYPTION_KEY!);
+		if (json == null) return null;
+		return JSON.parse(json) as Session;
+	} catch (e) {
+		logger.warn('Session deserialization failed');
+		return null;
+	}
+}
+
+async function getSessionFromUrl(
+	searchParams: URLSearchParams | undefined
+): Promise<Session | null> {
+	if (searchParams == null) return null;
 	const hash = searchParams.get('hash');
 	if (!hash) return null;
 
@@ -47,14 +70,60 @@ export const checkClientAuth = async (searchParams: URLSearchParams) => {
 		return null;
 	}
 
-	const id = searchParams.get('id')!;
+	const id = +searchParams.get('id')!;
 
-	const authDate: number = +searchParams.get('auth_date')!;
-	const nowDate: number = new Date().getTime() / 1000;
-	if (nowDate - authDate > TG_AUTH_TTL_SECONDS) {
+	const authDateRaw = searchParams.get('auth_date');
+	if (authDateRaw == null) return null;
+	const authDate: number = +authDateRaw * 1000;
+	const nowDate: number = Date.now();
+	if (nowDate - authDate > tgUrlAuthTtlMilli) {
 		logger.warn({ userId: id }, 'Stale tg auth');
 		return null;
 	}
 
-	return { id };
-};
+	return {
+		tgId: id,
+		roles: ['user'],
+		authDate: Date.now()
+	};
+}
+
+function getSessionFromCookie(cookies: Cookies): Session | null {
+	const cookie = cookies.get(cookieName);
+	if (cookie == null) return null;
+
+	let session = deserializeSession(cookie);
+	if (session == null) {
+		return null;
+	}
+
+	if (session.authDate == null) return null;
+	const authDate = +session.authDate;
+	const now = Date.now();
+	if (authDate + cookieTtlMilli < now) {
+		return null;
+	}
+
+	if (session.tgId == null) return null;
+	return session;
+}
+
+function storeSessionToCookie(session: Session, cookies: Cookies) {
+	cookies.set(cookieName, serializeSession(session), {
+		expires: new Date(session.authDate + cookieTtlMilli),
+		path: '/order',
+		httpOnly: true,
+		secure: true,
+		sameSite: 'lax'
+	});
+}
+
+export async function authenticateUser(cookies: Cookies, searchParams?: URLSearchParams) {
+	const urlSession = await getSessionFromUrl(searchParams);
+	if (urlSession != null) {
+		storeSessionToCookie(urlSession, cookies);
+		return urlSession;
+	} else {
+		return getSessionFromCookie(cookies);
+	}
+}

--- a/src/lib/server/bot.ts
+++ b/src/lib/server/bot.ts
@@ -12,7 +12,7 @@ const escapeMarkdown = (s: string) => {
 	return s;
 };
 
-export const sendOrder = async (order: Order, userId: string, chatId: string): Promise<number> => {
+export const sendOrder = async (order: Order, userId: number, chatId: string): Promise<number> => {
 	const mention = `[${escapeMarkdown(order.name)}](tg://user?id=${userId})`;
 	const itemsString = order.orderedItems
 		.map((item) => {

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -1,0 +1,16 @@
+import { env } from '$env/dynamic/private';
+
+function checkSessionEncryptionKey() {
+	const key = env.COOKIE_ENCRYPTION_KEY;
+	if (key == null) {
+		throw new Error('COOKIE_ENCRYPTION_KEY is not set');
+	}
+
+	if (Buffer.from(key, 'base64').length !== 32) {
+		throw new Error('COOKIE_ENCRYPTION_KEY must be a base64-encoded 32-byte key');
+	}
+}
+
+export function validateConfig() {
+	checkSessionEncryptionKey();
+}

--- a/src/lib/server/encryption.test.ts
+++ b/src/lib/server/encryption.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { decrypt, encrypt } from '$lib/server/encryption';
+
+describe('encryption', () => {
+	it('should encrypt and decrypt', () => {
+		const key = 'lVmBmAQEnFiLGPAR0f4k5K3GwNXc5pmDcE7boU2y/5w=';
+		const sourceData = 'someData';
+
+		const encrypted = encrypt(sourceData, key);
+		expect(encrypted).not.toBe(sourceData);
+
+		const decryptedData = decrypt(encrypted, key);
+		expect(decryptedData).toBe(sourceData);
+	});
+
+	it('should return null when decrypting with wrong key', () => {
+		const key = 'lVmBmAQEnFiLGPAR0f4k5K3GwNXc5pmDcE7boU2y/5w=';
+		const sourceData = 'someData';
+
+		const encrypted = encrypt(sourceData, key);
+		expect(encrypted).not.toBe(sourceData);
+
+		const wrongKey = '3rqh1njB/BrxaZ9ellVyp5cK4vaK3uEtQil1W8jZ6TE=';
+		const decryptedData = decrypt(encrypted, wrongKey);
+		expect(decryptedData).toBe(null);
+	});
+
+	it('should throw if key has wrong size', () => {
+		const badKey = '/VX+TrWpNqA=';
+
+		expect(() => {
+			encrypt('plaintext', badKey);
+		}).toThrow('Key must be exactly 32 bytes.');
+
+		expect(() => {
+			decrypt('ciphertext', badKey);
+		}).toThrow('Key must be exactly 32 bytes.');
+	});
+
+	it('should return null if data was tampered', () => {
+		const plaintext = 'someData';
+		const key = 'lVmBmAQEnFiLGPAR0f4k5K3GwNXc5pmDcE7boU2y/5w=';
+
+		const payload = Buffer.from(encrypt(plaintext, key), 'base64');
+		// flip one byte
+		payload[0] = ~payload[0] & 0xff;
+		const alteredPayload = payload.toString('base64');
+
+		const decrypted = decrypt(alteredPayload, key);
+		expect(decrypted).toBe(null);
+	});
+});

--- a/src/lib/server/encryption.ts
+++ b/src/lib/server/encryption.ts
@@ -1,0 +1,62 @@
+import * as crypto from 'crypto';
+import { logger } from '$lib/server/logger';
+
+const ALGORITHM = 'chacha20-poly1305';
+const KEY_BYTE_LENGTH = 32;
+const IV_BYTE_LENGTH = 12;
+const AUTH_TAG_BYTE_LENGTH = 16;
+const ENCODING: BufferEncoding = 'base64';
+
+export function encrypt(plaintext: string, keyString: string): string {
+	const key = Buffer.from(keyString, ENCODING);
+	if (key.length !== KEY_BYTE_LENGTH) {
+		throw new Error(`Key must be exactly ${KEY_BYTE_LENGTH} bytes.`);
+	}
+
+	const iv = crypto.randomBytes(IV_BYTE_LENGTH);
+
+	const cipher = crypto.createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_BYTE_LENGTH });
+
+	const encryptedUpdate = cipher.update(plaintext, 'utf8');
+	const encryptedFinal = cipher.final();
+	const ciphertext = Buffer.concat([encryptedUpdate, encryptedFinal]);
+
+	const authTag = cipher.getAuthTag();
+
+	const payload = Buffer.concat([iv, ciphertext, authTag]);
+	return payload.toString(ENCODING);
+}
+
+export function decrypt(textPayload: string, keyString: string): string | null {
+	const key = Buffer.from(keyString, ENCODING);
+	if (key.length !== KEY_BYTE_LENGTH) {
+		throw new Error(`Key must be exactly ${KEY_BYTE_LENGTH} bytes.`);
+	}
+
+	try {
+		const totalBuffer = Buffer.from(textPayload, ENCODING);
+		if (totalBuffer.length < IV_BYTE_LENGTH + AUTH_TAG_BYTE_LENGTH) {
+			return null;
+		}
+
+		const iv = totalBuffer.subarray(0, IV_BYTE_LENGTH);
+		const authTag = totalBuffer.subarray(totalBuffer.length - AUTH_TAG_BYTE_LENGTH);
+		const ciphertext = totalBuffer.subarray(
+			IV_BYTE_LENGTH,
+			totalBuffer.length - AUTH_TAG_BYTE_LENGTH
+		);
+
+		const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
+			authTagLength: AUTH_TAG_BYTE_LENGTH
+		});
+		decipher.setAuthTag(authTag);
+
+		let decrypted = decipher.update(ciphertext, undefined, 'utf-8');
+		decrypted += decipher.final();
+
+		return decrypted;
+	} catch (e) {
+		logger.error(e, 'Decryption failed');
+		return null;
+	}
+}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -10,3 +10,12 @@ interface Order {
 		qty: number;
 	}[];
 }
+
+type Role = 'admin' | 'user';
+
+interface Session {
+	tgId: number;
+	roles: Role[];
+	// epoch milli
+	authDate: number;
+}

--- a/src/routes/order/ConfirmStep.svelte
+++ b/src/routes/order/ConfirmStep.svelte
@@ -19,7 +19,7 @@
 		const order = { name, orderedItems } satisfies Order;
 		try {
 			sending = true;
-			const response = await fetch(window.location.pathname + window.location.search, {
+			const response = await fetch(window.location.pathname, {
 				method: 'POST',
 				body: JSON.stringify(order),
 				headers: {

--- a/src/routes/order/[linkId]/+page.server.ts
+++ b/src/routes/order/[linkId]/+page.server.ts
@@ -1,7 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { getName } from '$lib/server/database';
 import { error } from '@sveltejs/kit';
-import { checkClientAuth } from '$lib/server/auth';
+import { authenticateUser } from '$lib/server/auth';
 import { ZonedDateTime } from '@js-joda/core';
 import { APP_TZ } from '$lib/server/utils';
 import { getMenuByLinkId } from '$lib/server/menu';
@@ -16,9 +16,9 @@ const WEEKDAYS = [
 	'воскресенье'
 ];
 
-export const load: PageServerLoad = async ({ url, params, setHeaders }) => {
-	const user = await checkClientAuth(url.searchParams);
-	if (!user) {
+export const load: PageServerLoad = async ({ url, params, setHeaders, cookies }) => {
+	const session = await authenticateUser(cookies, url.searchParams);
+	if (!session) {
 		throw error(401, 'Unauthorized');
 	}
 
@@ -47,6 +47,6 @@ export const load: PageServerLoad = async ({ url, params, setHeaders }) => {
 	return {
 		items: menu?.items ?? [],
 		day,
-		name: await getName(user.id)
+		name: await getName(session.tgId + '')
 	};
 };

--- a/src/routes/order/[linkId]/+server.ts
+++ b/src/routes/order/[linkId]/+server.ts
@@ -3,15 +3,15 @@ import * as bot from '$lib/server/bot';
 import { error } from '@sveltejs/kit';
 import { setName } from '$lib/server/database';
 import { logger } from '$lib/server/logger';
-import { checkClientAuth } from '$lib/server/auth';
+import { authenticateUser } from '$lib/server/auth';
 import { getLocationByLinkId } from '$lib/server/location';
 import { saveOrder } from '$lib/server/order';
 
 const usedNonces = new Set();
 
-export const POST: RequestHandler = async ({ request, params, url }) => {
-	const user = await checkClientAuth(url.searchParams);
-	if (!user) {
+export const POST: RequestHandler = async ({ request, params, cookies }) => {
+	const session = await authenticateUser(cookies);
+	if (!session) {
 		throw error(401, 'Unauthorized');
 	}
 
@@ -27,10 +27,10 @@ export const POST: RequestHandler = async ({ request, params, url }) => {
 	if (!loc) throw error(404, 'Location not found');
 	const locationId = loc.id;
 
-	const messageId = await bot.sendOrder(order, user.id, loc.chatId);
+	const messageId = await bot.sendOrder(order, session.tgId, loc.chatId);
 	await saveOrder({
 		locationId,
-		telegramId: user.id,
+		telegramId: session.tgId + '',
 		name: order.name,
 		orderedItems: order.orderedItems,
 		receiptDate: loc.receiptDate,
@@ -38,11 +38,11 @@ export const POST: RequestHandler = async ({ request, params, url }) => {
 		messageId
 	});
 
-	await setName(user.id, order.name);
+	await setName(session.tgId + '', order.name);
 
 	if (nonce) {
 		usedNonces.add(nonce);
 	}
-	logger.info({ userId: user.id, order, locationId }, 'created order.ts');
+	logger.info({ userId: session.tgId, order, locationId }, 'created order.ts');
 	return new Response(null, { status: 201 });
 };


### PR DESCRIPTION
**Replaces ephemeral Telegram URL-based auth with persistent encrypted session cookies.**

### What changed

- **Session cookies** — After Telegram Login Widget validation, an encrypted session cookie (`ChaCha20-Poly1305`, 32-byte key) is set instead of re-validating the URL signature on every request. Cookie TTL: 18h, `httpOnly`, `secure`, `sameSite:lax`, scoped to `/order`.
- **`authenticateUser(cookies, searchParams?)** — New unified auth entry point. Tries URL params first (Telegram widget → sets cookie), then falls back to session cookie. Replaces `checkClientAuth`.
- **`encrypt`/`decrypt`** (`src/lib/server/encryption.ts`) — AEAD encryption with authenticated data, returns `null` on tampering/decryption failure. Covered by unit tests (wrong key, tampered payload, invalid key size).
- **`validateConfig()`** (`src/lib/server/config.ts`) — Startup check ensuring `COOKIE_ENCRYPTION_KEY` is present and a valid 32-byte base64 string.
- **User ID type** — `string` → `number` (`tgId`), matching Telegram's `id` field. Removed unused `App.Locals.userId`.
- **URL auth TTL tightened** — 24h → **60s** (Telegram widget link is now only valid for 60 seconds before a cookie is required).
- **CI** — `COOKIE_ENCRYPTION_KEY` added to GitHub Actions build step.
- **Cleanup** — Removed demo spec test.
