### PR TITLE
auth: add Telegram Mini App login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ services:
       DB_URL: 'file:/app/data/db.sqlite3'
       COOKIE_ENCRYPTION_KEY: 'generate using <openssl rand -base64 32>'
       FEATURE_DISABLE_PRICE_PARSING: 'true' # optional, skip price parsing in menu items
+      FEATURE_DISABLE_MINIAPP: 'true' # optional, hide miniapp (web_app) login/order buttons
     volumes:
       - './data:/app/data'
 ```

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,16 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	interface Window {
+		Telegram?: {
+			WebApp?: {
+				initData: string;
+				ready: () => void;
+				expand: () => void;
+			};
+		};
+	}
 }
 
 export {};

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -1,0 +1,95 @@
+import { createHash, createHmac } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { env } from '$env/dynamic/private';
+import { validateWebAppInitData } from './auth';
+
+// In vitest, $env/dynamic/private is a snapshot of loadEnv (files override process.env),
+// so auth.ts sees the same value as env.BOT_TOKEN here — sign with that, not a hardcoded mock.
+const TOKEN = env.BOT_TOKEN ?? 'test-bot-token';
+
+function buildInitData(overrides: Record<string, string> = {}): URLSearchParams {
+	const params = new URLSearchParams({
+		auth_date: String(Math.floor(Date.now() / 1000)),
+		query_id: 'test-query-id',
+		user: JSON.stringify({ id: 42, first_name: 'Test', is_bot: false })
+	});
+	for (const [key, value] of Object.entries(overrides)) {
+		params.set(key, value);
+	}
+	return params;
+}
+
+function dataCheckString(params: URLSearchParams): string {
+	return [...params.keys()]
+		.filter((key) => key !== 'hash')
+		.sort()
+		.map((key) => `${key}=${params.get(key)}`)
+		.join('\n');
+}
+
+// Independent implementation via node:crypto: secret = HMAC("WebAppData" as key, BOT_TOKEN)
+function signInitData(params: URLSearchParams): string {
+	const secret = createHmac('sha256', 'WebAppData').update(TOKEN).digest();
+	return createHmac('sha256', secret).update(dataCheckString(params)).digest('hex');
+}
+
+describe('validateWebAppInitData', () => {
+	it('accepts valid initData', async () => {
+		const params = buildInitData();
+		params.set('hash', signInitData(params));
+
+		const session = await validateWebAppInitData(params.toString(), ['admin']);
+
+		expect(session?.tgId).toBe(42);
+		expect(session?.roles).toEqual(['admin']);
+		expect(session?.validUntil).toBeGreaterThan(Date.now());
+	});
+
+	it('accepts explicit user roles', async () => {
+		const params = buildInitData();
+		params.set('hash', signInitData(params));
+
+		const session = await validateWebAppInitData(params.toString(), ['user']);
+
+		expect(session?.tgId).toBe(42);
+		expect(session?.roles).toEqual(['user']);
+	});
+
+	it('rejects data with tampered user id', async () => {
+		const params = buildInitData();
+		const hash = signInitData(params);
+		params.set('user', JSON.stringify({ id: 999, first_name: 'Evil' }));
+		params.set('hash', hash);
+
+		expect(await validateWebAppInitData(params.toString(), ['admin'])).toBeNull();
+	});
+
+	it('rejects initData without a hash', async () => {
+		expect(await validateWebAppInitData(buildInitData().toString(), ['admin'])).toBeNull();
+	});
+
+	it('rejects stale auth_date', async () => {
+		const stale = buildInitData({
+			auth_date: String(Math.floor(Date.now() / 1000) - 120)
+		});
+		stale.set('hash', signInitData(stale));
+
+		expect(await validateWebAppInitData(stale.toString(), ['admin'])).toBeNull();
+	});
+
+	it('rejects an invalid user payload', async () => {
+		const params = buildInitData({ user: 'not-json' });
+		params.set('hash', signInitData(params));
+
+		expect(await validateWebAppInitData(params.toString(), ['admin'])).toBeNull();
+	});
+
+	it('rejects data signed with the login-widget secret', async () => {
+		const params = buildInitData();
+		const widgetSecret = createHash('sha256').update(TOKEN).digest();
+		const hash = createHmac('sha256', widgetSecret).update(dataCheckString(params)).digest('hex');
+		params.set('hash', hash);
+
+		expect(await validateWebAppInitData(params.toString(), ['admin'])).toBeNull();
+	});
+});

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -9,6 +9,8 @@ const { BOT_TOKEN, COOKIE_ENCRYPTION_KEY } = env;
 const tgUrlAuthTtlMilli = 60_000;
 const cookieName = 'session';
 
+const enc = new TextEncoder();
+
 const createHmac = async (secret: ArrayBuffer, data: ArrayBuffer) => {
 	const algorithm = { name: 'HMAC', hash: 'SHA-256' };
 	const key = await crypto.subtle.importKey('raw', secret, algorithm, false, ['sign']);
@@ -25,12 +27,38 @@ const hex = (data: ArrayBuffer) => {
 		.join('');
 };
 
+// Login widget: secret = SHA256(BOT_TOKEN)
 const isLinkSignatureValid = async (hash: string, data: string) => {
-	const enc = new TextEncoder();
 	const secretKey = await createHash(enc.encode(BOT_TOKEN).buffer);
 	const digest = await createHmac(secretKey, enc.encode(data).buffer);
 	return hash === hex(digest);
 };
+
+// Miniapp initData: secret = HMAC_SHA256(key="WebAppData", data=BOT_TOKEN)
+const isWebAppSignatureValid = async (hash: string, data: string) => {
+	const secretKey = await createHmac(enc.encode('WebAppData').buffer, enc.encode(BOT_TOKEN).buffer);
+	const digest = await createHmac(secretKey, enc.encode(data).buffer);
+	return hash === hex(digest);
+};
+
+function buildDataCheckString(params: URLSearchParams): string | null {
+	if (params.get('hash') == null) return null;
+	return [...params.keys()]
+		.filter((key) => key !== 'hash')
+		.sort()
+		.map((key) => `${key}=${params.get(key)}`)
+		.join('\n');
+}
+
+function isAuthDateFresh(authDateRaw: string | null, userId: number): boolean {
+	if (authDateRaw == null) return false;
+	const authDate = +authDateRaw * 1000;
+	if (Date.now() - authDate > tgUrlAuthTtlMilli) {
+		logger.warn({ userId }, 'Stale tg auth');
+		return false;
+	}
+	return true;
+}
 
 function serializeSession(session: Session): string {
 	const json = JSON.stringify(session);
@@ -53,27 +81,54 @@ async function getSessionFromUrl(
 	searchParams: URLSearchParams | undefined
 ): Promise<Session | null> {
 	if (searchParams == null) return null;
-	const hash = searchParams.get('hash');
-	if (!hash) return null;
+	const dataCheckString = buildDataCheckString(searchParams);
+	if (dataCheckString == null) return null;
 
-	const dataCheckString = [...searchParams.keys()]
-		.filter((key) => key !== 'hash')
-		.sort()
-		.map((key) => `${key}=${searchParams.get(key)}`)
-		.join('\n');
-
-	if (!(await isLinkSignatureValid(hash, dataCheckString))) {
+	if (!(await isLinkSignatureValid(searchParams.get('hash')!, dataCheckString))) {
 		return null;
 	}
 
 	const id = +searchParams.get('id')!;
 
-	const authDateRaw = searchParams.get('auth_date');
-	if (authDateRaw == null) return null;
-	const authDate: number = +authDateRaw * 1000;
-	const nowDate: number = Date.now();
-	if (nowDate - authDate > tgUrlAuthTtlMilli) {
-		logger.warn({ userId: id }, 'Stale tg auth');
+	if (!isAuthDateFresh(searchParams.get('auth_date'), id)) {
+		return null;
+	}
+
+	return {
+		tgId: id,
+		roles,
+		validUntil: nextMidnight()
+	};
+}
+
+export async function validateWebAppInitData(
+	initData: string,
+	roles: Role[]
+): Promise<Session | null> {
+	const params = new URLSearchParams(initData);
+	const dataCheckString = buildDataCheckString(params);
+	if (dataCheckString == null) return null;
+
+	if (!(await isWebAppSignatureValid(params.get('hash')!, dataCheckString))) {
+		logger.warn('Invalid webapp initData signature');
+		return null;
+	}
+
+	const userRaw = params.get('user');
+	if (userRaw == null) return null;
+
+	let user: { id?: unknown };
+	try {
+		user = JSON.parse(userRaw);
+	} catch {
+		logger.warn('Invalid webapp user payload');
+		return null;
+	}
+
+	if (typeof user.id !== 'number') return null;
+	const id = user.id;
+
+	if (!isAuthDateFresh(params.get('auth_date'), id)) {
 		return null;
 	}
 
@@ -103,7 +158,7 @@ function getSessionFromCookie(cookies: Cookies): Session | null {
 	return session;
 }
 
-function storeSessionToCookie(session: Session, cookies: Cookies, path: string) {
+export function storeSessionToCookie(session: Session, cookies: Cookies, path: string) {
 	cookies.set(cookieName, serializeSession(session), {
 		expires: new Date(session.validUntil),
 		path,

--- a/src/lib/server/bot.ts
+++ b/src/lib/server/bot.ts
@@ -50,7 +50,7 @@ async function sendAdminButton(ctx: CommandContext<Context>) {
 		ctxLogger.warn('Rejected sending admin button');
 		return ctx.reply('Не твой уровень, дорогой!');
 	}
-	const button = {
+	const button1 = {
 		text: 'Войти в админку',
 		login_url: {
 			url: `${APP_URL}/_/edit`
@@ -58,10 +58,21 @@ async function sendAdminButton(ctx: CommandContext<Context>) {
 		style: 'danger'
 	};
 
+	const button2 = {
+		text: 'Войти через мини-апп',
+		web_app: {
+			url: `${APP_URL}/login/_/edit`
+		},
+		style: 'danger'
+	};
+
+	const keyboard =
+		process.env.FEATURE_DISABLE_MINIAPP === 'true' ? [[button1]] : [[button1], [button2]];
+
 	try {
 		const result = await bot.api.sendMessage(chatId, 'Вход в панель управления по кнопке ниже', {
 			// @ts-ignore
-			reply_markup: { inline_keyboard: [[button]] },
+			reply_markup: { inline_keyboard: keyboard },
 			disable_notification: true
 		});
 		const messageId = result.message_id;

--- a/src/lib/server/menu-link.ts
+++ b/src/lib/server/menu-link.ts
@@ -11,14 +11,24 @@ let messageDeletionTimer: NodeJS.Timeout | null = null;
 export async function sendMenuLink(locationId: string, chatId: string): Promise<void> {
 	const linkId = await createMenuLink(locationId, +chatId);
 
-	const button = {
+	const button1 = {
 		text: 'Создать заказ',
 		login_url: {
 			url: `${env.APP_URL}/order/${linkId}`
 		}
 	};
+	const button2 = {
+		text: 'Создать заказ (мини-апп)',
+		web_app: {
+			url: `${env.APP_URL}/login/order/${linkId}`
+		}
+	};
+
+	const keyboard =
+		process.env.FEATURE_DISABLE_MINIAPP === 'true' ? [[button1]] : [[button1], [button2]];
+
 	const result = await bot.api.sendMessage(chatId, 'Нажмите на кнопку ниже, чтобы создать заказ', {
-		reply_markup: { inline_keyboard: [[button]] }
+		reply_markup: { inline_keyboard: keyboard }
 	});
 
 	const messageId = result.message_id;

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { page } from '$app/state';
+</script>
+
+<svelte:head>
+	<title>{page.status}</title>
+</svelte:head>
+
+<main>
+	<h1>{page.status} {page.error?.message ?? ''}</h1>
+	{#if page.status === 401}
+		<p>Не получается войти? Попробуйте мини-апп</p>
+	{/if}
+</main>
+
+<style>
+	main {
+		max-width: min(65ch, 100% - 1rem);
+		margin-inline: auto;
+		padding: 1rem;
+	}
+
+	h1 {
+		font-family: system-ui, sans-serif;
+		font-size: 1.25rem;
+	}
+
+	p {
+		font-family: system-ui, sans-serif;
+		line-height: 1.5;
+	}
+</style>

--- a/src/routes/_/edit/menu/parseMenuItem.test.ts
+++ b/src/routes/_/edit/menu/parseMenuItem.test.ts
@@ -53,13 +53,6 @@ describe('parseMenuItem', () => {
 	it('does not parse number at the start as price', () => {
 		expect(parseMenuItem('2 Coffee')).toEqual({ name: '2 Coffee', price: 0 });
 	});
-
-	it('skips price parsing when FEATURE_DISABLE_PRICE_PARSING=true', async () => {
-		vi.resetModules();
-		process.env.FEATURE_DISABLE_PRICE_PARSING = 'true';
-		const { parseMenuItem: p } = await import('$lib/server/menuItemParser');
-		expect(p('Latte 5,50 BYN')).toEqual({ name: 'Latte 5,50 BYN', price: 0 });
-	});
 });
 
 describe('menuItemToString', () => {
@@ -83,5 +76,14 @@ describe('round-trip', () => {
 		for (const { input, expected } of inputs) {
 			expect(menuItemToString(parseMenuItem(input))).toBe(expected);
 		}
+	});
+});
+
+describe('parseMenuItem with FEATURE_DISABLE_PRICE_PARSING', () => {
+	it('skips price parsing when FEATURE_DISABLE_PRICE_PARSING=true', async () => {
+		vi.resetModules();
+		process.env.FEATURE_DISABLE_PRICE_PARSING = 'true';
+		const { parseMenuItem: p } = await import('$lib/server/menuItemParser');
+		expect(p('Latte 5,50 BYN')).toEqual({ name: 'Latte 5,50 BYN', price: 0 });
 	});
 });

--- a/src/routes/login/[...target]/+page.server.ts
+++ b/src/routes/login/[...target]/+page.server.ts
@@ -1,0 +1,7 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ setHeaders }) => {
+	// Prevent the webview from caching and re-showing a stale login page
+	setHeaders({ 'Cache-Control': 'no-store' });
+	return {};
+};

--- a/src/routes/login/[...target]/+page.svelte
+++ b/src/routes/login/[...target]/+page.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+
+	let status = $state<'working' | 'error'>('working');
+	let errorMessage = $state('');
+
+	async function getInitData(): Promise<string> {
+		// telegram-web-app.js may finish loading after the app scripts — poll briefly.
+		for (let i = 0; i < 50; i++) {
+			const initData = window.Telegram?.WebApp?.initData;
+			if (initData) return initData;
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		return window.Telegram?.WebApp?.initData ?? '';
+	}
+
+	onMount(async () => {
+		const webApp = window.Telegram?.WebApp;
+		webApp?.ready();
+		webApp?.expand();
+
+		const target = page.params.target;
+		const initData = await getInitData();
+
+		try {
+			const res = await fetch(`/login/${target}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ initData })
+			});
+			if (res.ok) {
+				const body = (await res.json()) as { redirectTo: string };
+				location.assign(body.redirectTo);
+				return;
+			}
+			status = 'error';
+			if (res.status === 400) {
+				errorMessage = 'Откройте эту страницу через кнопку в Telegram.';
+			} else if (res.status === 403) {
+				errorMessage = 'У вас нет доступа.';
+			} else {
+				errorMessage = 'Не удалось войти.';
+			}
+		} catch {
+			status = 'error';
+			errorMessage = 'Не удалось связаться с сервером.';
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Вход</title>
+	<script src="https://telegram.org/js/telegram-web-app.js?63"></script>
+</svelte:head>
+
+{#if status === 'working'}
+	<p>Входим…</p>
+{:else}
+	<p>{errorMessage}</p>
+{/if}
+
+<style>
+	:global(body) {
+		background: var(--color-bg, #111);
+		color: var(--color-fg, #eee);
+	}
+	p {
+		font-family: system-ui, sans-serif;
+		padding: 1rem;
+	}
+</style>

--- a/src/routes/login/[...target]/+server.ts
+++ b/src/routes/login/[...target]/+server.ts
@@ -1,0 +1,48 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { storeSessionToCookie, validateWebAppInitData } from '$lib/server/auth';
+
+type Scope = {
+	roles: Role[];
+	cookiePath: string;
+};
+
+function resolveScope(target: string): Scope | null {
+	const segments = target.split('/').filter(Boolean);
+	if (segments[0] === '_' && segments[1] === 'edit' && segments.length === 2) {
+		return { roles: ['admin'], cookiePath: '/_/edit' };
+	}
+	if (segments[0] === 'order' && segments.length === 2 && segments[1] !== '') {
+		return { roles: ['user'], cookiePath: '/order' };
+	}
+	return null;
+}
+
+export const POST: RequestHandler = async ({ request, params, cookies }) => {
+	const target = params.target ?? '';
+
+	const scope = resolveScope(target);
+	if (scope == null) {
+		return json({ ok: false }, { status: 404 });
+	}
+
+	let initData = '';
+	try {
+		const body = (await request.json()) as { initData?: unknown };
+		initData = typeof body.initData === 'string' ? body.initData : '';
+	} catch {
+		return json({ ok: false }, { status: 400 });
+	}
+
+	if (!initData) {
+		return json({ ok: false }, { status: 400 });
+	}
+
+	const session = await validateWebAppInitData(initData, scope.roles);
+	if (session == null) {
+		return json({ ok: false }, { status: 401 });
+	}
+
+	storeSessionToCookie(session, cookies, scope.cookiePath);
+	return json({ ok: true, redirectTo: `/${target}` });
+};


### PR DESCRIPTION
Adds a web_app (mini-app) alternative to the Telegram Login Widget:

- validateWebAppInitData() verifies initData via HMAC-SHA256 with secret = HMAC("WebAppData", BOT_TOKEN); refactors shared data-check-string and auth-date freshness helpers
- new /login/[...target] route exchanges initData for a session cookie (roles scoped by target: admin for /_/edit, user for /order) and redirects to the original page
- admin login and order buttons now include a web_app variant, gated by the FEATURE_DISABLE_MINIAPP env flag
- custom +error.svelte hints at the mini-app on 401
- Window.Telegram.WebApp type declarations and README docs
- unit tests for validateWebAppInitData (valid, tampered, stale, missing hash, wrong secret)